### PR TITLE
[EZAF-12691]To fix internal server error

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -2216,7 +2216,7 @@ class BaseSecurityManager(AbstractSecurityManager):
 
     def load_user(self, pk):
         user = self.get_user_by_id(int(pk))
-        if user.is_active:
+        if user is not None and user.is_active:
             return user
 
     def load_user_jwt(self, _jwt_header, jwt_data):


### PR DESCRIPTION
Getting Internal server error when a user is deleted and the user is trying to access the superset.
The error looks like as below: 
` File "/usr/local/lib/python3.10/site-packages/flask_appbuilder/security/manager.py", line 2219, in load_user
    if user.is_active:
AttributeError: 'NoneType' object has no attribute 'is_active'`

So adding condition to check user is not None.


<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

<!--- Describe the change below, including rationale and design decisions -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
